### PR TITLE
Fix multi-prerelease branch issue

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -9223,7 +9223,7 @@ async function checkTag(octokit, tagName) {
     return false;
 }
 
-async function getLatestTag(octokit, boolAll = true) {
+async function getLatestTag(octokit, branchName, boolAll = true) {
 
     const tags = await octokit.paginate(
         octokit.rest.repos.listTags,
@@ -9234,13 +9234,14 @@ async function getLatestTag(octokit, boolAll = true) {
         },
         response => response.data.filter(tag => semver.clean(tag.name) !== null)
     )
-
+    
     // ensure the highest version number is the last element
     tags
         .sort((a, b) => semver.compare(semver.clean(a.name), semver.clean(b.name)));
 
     if (boolAll) {
-        return tags.pop();
+        const branchTags = tags.filter((b) => b.name.includes(branchName));
+        return branchTags.pop();
     }
 
     // filter prereleases
@@ -9436,8 +9437,8 @@ async function action() {
 
         core.info(`maching refs: ${ sha }`);
 
-        const latestTag = await getLatestTag(octokit);
-        const latestMainTag = await getLatestTag(octokit, false);
+        const latestTag = await getLatestTag(octokit, branchName);
+        const latestMainTag = await getLatestTag(octokit, branchName, false);
 
         core.info(`the latest tag of the repository ${ JSON.stringify(latestTag, undefined, 2) }`);
         core.info(`the latest main tag of the repository ${ JSON.stringify(latestMainTag, undefined, 2) }`);
@@ -9450,7 +9451,7 @@ async function action() {
             throw new Error("no new commits, avoid tagging");
         }
 
-        core.info(`The repo tags: ${ JSON.stringify(latestTag, undefined, 2) }`);
+        // core.info(`The repo tags: ${ JSON.stringify(latestTag, undefined, 2) }`);
 
         const version   = semver.clean(versionTag);
 

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ async function checkTag(octokit, tagName) {
     return false;
 }
 
-async function getLatestTag(octokit, boolAll = true) {
+async function getLatestTag(octokit, branchName, boolAll = true) {
 
     const tags = await octokit.paginate(
         octokit.rest.repos.listTags,
@@ -38,13 +38,14 @@ async function getLatestTag(octokit, boolAll = true) {
         },
         response => response.data.filter(tag => semver.clean(tag.name) !== null)
     )
-
+    
     // ensure the highest version number is the last element
     tags
         .sort((a, b) => semver.compare(semver.clean(a.name), semver.clean(b.name)));
 
     if (boolAll) {
-        return tags.pop();
+        const branchTags = tags.filter((b) => b.name.includes(branchName));
+        return branchTags.pop();
     }
 
     // filter prereleases
@@ -240,8 +241,8 @@ async function action() {
 
         core.info(`maching refs: ${ sha }`);
 
-        const latestTag = await getLatestTag(octokit);
-        const latestMainTag = await getLatestTag(octokit, false);
+        const latestTag = await getLatestTag(octokit, branchName);
+        const latestMainTag = await getLatestTag(octokit, branchName, false);
 
         core.info(`the latest tag of the repository ${ JSON.stringify(latestTag, undefined, 2) }`);
         core.info(`the latest main tag of the repository ${ JSON.stringify(latestMainTag, undefined, 2) }`);

--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,7 @@ async function getLatestTag(octokit, branchName, boolAll = true) {
 
     if (boolAll) {
         const branchTags = tags.filter((b) => b.name.includes(branchName));
+        core.info(branchTags);
         return branchTags.pop();
     }
 
@@ -255,7 +256,7 @@ async function action() {
             throw new Error("no new commits, avoid tagging");
         }
 
-        core.info(`The repo tags: ${ JSON.stringify(latestTag, undefined, 2) }`);
+        // core.info(`The repo tags: ${ JSON.stringify(latestTag, undefined, 2) }`);
 
         const version   = semver.clean(versionTag);
 

--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,6 @@ async function getLatestTag(octokit, branchName, boolAll = true) {
 
     if (boolAll) {
         const branchTags = tags.filter((b) => b.name.includes(branchName));
-        core.info(branchTags);
         return branchTags.pop();
     }
 


### PR DESCRIPTION
If there were multiple prerelease branches, the action would fail when pushing in a non-linear fashion.

e.g. `0.10.2-dev.0` exists.
push to `qa` creates `0.10.2-qa.0`
now push to `dev`, and the action would find `0.10.2-qa.0` as the latest tag, and therefore try to create `0.10.2-dev.0` even though it already exists.